### PR TITLE
Fix endpoint for im.open method

### DIFF
--- a/src/api/im.coffee
+++ b/src/api/im.coffee
@@ -7,7 +7,7 @@ class IM extends BaseClass
     history: '/api/im.history'
     list: '/api/im.list'
     mark: '/api/im.mark'
-    open: '/api/im.post'
+    open: '/api/im.open'
 
   #
   # Official API Methods


### PR DESCRIPTION
Hi!

I discovered the endpoint for the [im.open](https://api.slack.com/methods/im.open) method is wrong. This PR fixes that.
